### PR TITLE
feat: Add transfer ownership script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,18 @@ L2_DEPLOYER_KEY=
 
 CANONICAL_STATE_CHAIN_ADDR=0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512
 CHALLENGE_ADDR=0x0165878A594ca255338adfa4d48449f69242Eb8F
+
+## -------------------------------- ##
+## Transfer ownership to Safe       ##
+## -------------------------------- ##
+
+# Contract proxy addresses
+LIGHT_LINK_PORTAL_ADDR=
+CHAIN_ORACLE_ADDR=
+CANONICAL_STATE_CHAIN_ADDR=
+SYSTEM_CONFIG_ADDR=
+CHALLENGE_ADDR=
+# The Safe wallet address to transfer ownership to
+SAFE_WALLET_ADDRESS=
+# The private key of the current admin/owner of the contracts
+CURRENT_ADMIN_KEY=

--- a/.env.example
+++ b/.env.example
@@ -48,13 +48,16 @@ CHALLENGE_ADDR=0x0165878A594ca255338adfa4d48449f69242Eb8F
 ## -------------------------------- ##
 ## Transfer ownership to Safe       ##
 ## -------------------------------- ##
-
-# Contract proxy addresses
-LIGHT_LINK_PORTAL_ADDR=
+# Contract PROXY addresses (transferOwner() only)
 CHAIN_ORACLE_ADDR=
 CANONICAL_STATE_CHAIN_ADDR=
-SYSTEM_CONFIG_ADDR=
 CHALLENGE_ADDR=
+# (transferOwner() & changeAdmin())
+LIGHT_LINK_PORTAL_ADDR=
+SYSTEM_CONFIG_ADDR=
+# (changeAdmin() only)
+L1_CROSS_DOMAIN_MESSENGER_ADDR=
+L1_STANDARD_BRIDGE_ADDR=
 # The Safe wallet address to transfer ownership to
 SAFE_WALLET_ADDRESS=
 # The private key of the current admin/owner of the contracts

--- a/scripts/hardhat/tools/transferOwner.ts
+++ b/scripts/hardhat/tools/transferOwner.ts
@@ -1,0 +1,172 @@
+import { ethers } from "hardhat";
+import { log } from "../lib/log";
+import * as readline from "readline";
+import { Contract, Wallet } from "ethers";
+
+// Environment variables
+const SAFE_WALLET_ADDRESS = process.env.SAFE_WALLET_ADDRESS || "";
+const CURRENT_ADMIN_KEY = process.env.CURRENT_ADMIN_KEY || "";
+
+// Contract addresses
+const LIGHT_LINK_PORTAL_ADDR = process.env.LIGHT_LINK_PORTAL_ADDR;
+const CHAIN_ORACLE_ADDR = process.env.CHAIN_ORACLE_ADDR;
+const CANONICAL_STATE_CHAIN_ADDR = process.env.CANONICAL_STATE_CHAIN_ADDR;
+const SYSTEM_CONFIG_ADDR = process.env.SYSTEM_CONFIG_ADDR;
+const CHALLENGE_ADDR = process.env.CHALLENGE_ADDR;
+
+// Create wallet from private key
+const adminWallet = CURRENT_ADMIN_KEY ? new Wallet(CURRENT_ADMIN_KEY) : null;
+
+// Create readline interface for user confirmation
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+const askForConfirmation = async (message: string): Promise<boolean> => {
+  return new Promise((resolve) => {
+    rl.question(`${message} (y/n): `, (answer) => {
+      resolve(answer.toLowerCase() === "y" || answer.toLowerCase() === "yes");
+    });
+  });
+};
+
+const logEnvironmentVariables = () => {
+  log("=== ENVIRONMENT VARIABLES ===");
+  log(`SAFE_WALLET_ADDRESS: ${SAFE_WALLET_ADDRESS || "NOT SET"}`);
+  log(`CURRENT_ADMIN_KEY: ${adminWallet?.address || "NOT SET"}`);
+  log(`LIGHT_LINK_PORTAL_ADDR: ${LIGHT_LINK_PORTAL_ADDR || "NOT SET"}`);
+  log(`CHAIN_ORACLE_ADDR: ${CHAIN_ORACLE_ADDR || "NOT SET"}`);
+  log(`CANONICAL_STATE_CHAIN_ADDR: ${CANONICAL_STATE_CHAIN_ADDR || "NOT SET"}`);
+  log(`SYSTEM_CONFIG_ADDR: ${SYSTEM_CONFIG_ADDR || "NOT SET"}`);
+  log(`CHALLENGE_ADDR: ${CHALLENGE_ADDR || "NOT SET"}`);
+  log("=============================");
+};
+
+const transferOwnership = async (
+  contract: Contract,
+  contractName: string,
+  signer: Wallet,
+  newOwner: string,
+) => {
+  try {
+    const currentOwner = await contract.owner();
+    log(`\nCurrent ${contractName} owner: ${currentOwner}`);
+
+    if (currentOwner.toLowerCase() === newOwner.toLowerCase()) {
+      log(`${contractName} already owned by Safe wallet`);
+      return;
+    }
+
+    if (currentOwner.toLowerCase() !== signer.address.toLowerCase()) {
+      log(
+        `Warning: Signer (${signer.address}) is not the current owner of ${contractName} (${currentOwner})`,
+      );
+      return;
+    }
+
+    const tx = await contract.transferOwnership(newOwner);
+    await tx.wait();
+    log(`${contractName} ownership transferred to ${newOwner}, tx: ${tx.hash}`);
+  } catch (error) {
+    log(`Error transferring ${contractName} ownership: ${error}`);
+  }
+};
+
+const main = async () => {
+  logEnvironmentVariables();
+
+  if (!SAFE_WALLET_ADDRESS || !CURRENT_ADMIN_KEY || !adminWallet) {
+    throw new Error("Required environment variables are not set");
+  }
+
+  // Validate contract addresses
+  if (!LIGHT_LINK_PORTAL_ADDR)
+    throw new Error("Missing LIGHT_LINK_PORTAL_ADDR");
+  if (!CHAIN_ORACLE_ADDR) throw new Error("Missing CHAIN_ORACLE_ADDR");
+  if (!CANONICAL_STATE_CHAIN_ADDR)
+    throw new Error("Missing CANONICAL_STATE_CHAIN_ADDR");
+  if (!SYSTEM_CONFIG_ADDR) throw new Error("Missing SYSTEM_CONFIG_ADDR");
+  if (!CHALLENGE_ADDR) throw new Error("Missing CHALLENGE_ADDR");
+
+  const confirmed = await askForConfirmation(
+    `Are you sure you want to transfer ownership of all contracts to ${SAFE_WALLET_ADDRESS}?`,
+  );
+
+  if (!confirmed) {
+    log("Operation cancelled by user.");
+    rl.close();
+    return;
+  }
+
+  log(`Transferring ownership to Safe wallet: ${SAFE_WALLET_ADDRESS}`);
+  const signer = adminWallet.connect(ethers.provider);
+  log(`Using signer: ${signer.address}`);
+
+  // Transfer ownership for each contract
+  const lightLinkPortal = (await ethers.getContractAt(
+    "LightLinkPortal",
+    LIGHT_LINK_PORTAL_ADDR,
+    signer,
+  )) as unknown as Contract;
+  await transferOwnership(
+    lightLinkPortal,
+    "LightLinkPortal",
+    signer,
+    SAFE_WALLET_ADDRESS,
+  );
+
+  const chainOracle = (await ethers.getContractAt(
+    "ChainOracle",
+    CHAIN_ORACLE_ADDR,
+    signer,
+  )) as unknown as Contract;
+  await transferOwnership(
+    chainOracle,
+    "ChainOracle",
+    signer,
+    SAFE_WALLET_ADDRESS,
+  );
+
+  const canonicalStateChain = (await ethers.getContractAt(
+    "CanonicalStateChain",
+    CANONICAL_STATE_CHAIN_ADDR,
+    signer,
+  )) as unknown as Contract;
+  await transferOwnership(
+    canonicalStateChain,
+    "CanonicalStateChain",
+    signer,
+    SAFE_WALLET_ADDRESS,
+  );
+
+  const systemConfig = (await ethers.getContractAt(
+    "SystemConfig",
+    SYSTEM_CONFIG_ADDR,
+    signer,
+  )) as unknown as Contract;
+  await transferOwnership(
+    systemConfig,
+    "SystemConfig",
+    signer,
+    SAFE_WALLET_ADDRESS,
+  );
+
+  const challenge = (await ethers.getContractAt(
+    "Challenge",
+    CHALLENGE_ADDR,
+    signer,
+  )) as unknown as Contract;
+  await transferOwnership(challenge, "Challenge", signer, SAFE_WALLET_ADDRESS);
+
+  log("Ownership transfer complete!");
+  rl.close();
+};
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    rl.close();
+    process.exit(1);
+  });


### PR DESCRIPTION
- deployed fresh test contracts to sepolia
- ran transferOwner.ts script to transfer ownership to test wallet
- do we need to transfer proxy admin ownership to safe wallet also?
- we are using two types of proxies,
  - CoreProxy
  - Proxy

Deployed Test Contracts:
```
# [Test Deployment Addresses (proxy addresses)

# CoreProxy
#  canonicalStateChain: "0x722c7Ebee5b0251196fa346200a74DCd12520f4C"
#  challenge: "0xE9E9886f26FFa878ce30Ec3214f374C197621fF5"
#  chainOracle: "0x887C0704Ad6DAa41512C2746Ab22ADf7513D0F4E"
#  blobstreamX: "0xF0c6429ebAB2e7DC6e05DaFB61128bE21f13cb1e"
#  rlpReader: "0xc93CeDd294EE169628663B1464a268ff2Cab61eB" 

# Proxy
#  LightLinkPortal: "0x3C741a2F55271658Bb5b03579e2B9F2329fAB1e1" "(impl 0xcf109a9908027B67f41566726e3949C6908856bF)"
#  L1CrossDomainMessenger: "0x1799720F7bDE00bc235437fF29291CE9BDc707Eb" "(impl 0x1DdEcB40366BC30Dd2D4ee223AE47c589A174b62)"
#  L1StandardBridge: "0x98BD5BB48307d2312629cAAdC7f6CE0C8F099e24" "(impl 0x9750d8a2Bb9e1663c61A9e839eF0A267B668d703)"
#  SystemConfig: "0x496a97202cF4F6f1DDbD1F73D4bB2DeD1B50183e" "(impl 0xFC3Db31768E070c3227A2bb3E78bEeDFE2152E4b)"
```

Script Test Run
```
# [Ran transferOwner.ts script]

# npx hardhat run ./scripts/hardhat/tools/transferOwner.ts --network sepolia
# === ENVIRONMENT VARIABLES ===
# SAFE_WALLET_ADDRESS: 0x39cb5B122B616239554621c866760272c8C2008e
# CURRENT_ADMIN_KEY: 0x01D33E0D8801f1Aa5E71bff7b7548C3f857a06F2
# LIGHT_LINK_PORTAL_ADDR: 0x3C741a2F55271658Bb5b03579e2B9F2329fAB1e1
# CHAIN_ORACLE_ADDR: 0x887C0704Ad6DAa41512C2746Ab22ADf7513D0F4E
# CANONICAL_STATE_CHAIN_ADDR: 0x722c7Ebee5b0251196fa346200a74DCd12520f4C
# SYSTEM_CONFIG_ADDR: 0x496a97202cF4F6f1DDbD1F73D4bB2DeD1B50183e
# CHALLENGE_ADDR: 0xE9E9886f26FFa878ce30Ec3214f374C197621fF5
# =============================
# Are you sure you want to transfer ownership of all contracts to 0x39cb5B122B616239554621c866760272c8C2008e? (y/n): y
# Transferring ownership to Safe wallet: 0x39cb5B122B616239554621c866760272c8C2008e
# Using signer: 0x01D33E0D8801f1Aa5E71bff7b7548C3f857a06F2

# Current LightLinkPortal owner: 0x01D33E0D8801f1Aa5E71bff7b7548C3f857a06F2
# LightLinkPortal ownership transferred to 0x39cb5B122B616239554621c866760272c8C2008e, tx: 0xeded04c74d0a3a59f34396ef576140a8e0b4a8d5ae56bac7aaaf5c1fe9ce2f43

# Current ChainOracle owner: 0x01D33E0D8801f1Aa5E71bff7b7548C3f857a06F2
# ChainOracle ownership transferred to 0x39cb5B122B616239554621c866760272c8C2008e, tx: 0xa73b2aa9fa206c78b497d31f629c80515e18436068c1635303369a93c62b9a8b

# Current CanonicalStateChain owner: 0x01D33E0D8801f1Aa5E71bff7b7548C3f857a06F2
# CanonicalStateChain ownership transferred to 0x39cb5B122B616239554621c866760272c8C2008e, tx: 0x162ae67b1181e59da76167bffe52b070fb5c2e64d736650a5cf4f6f470c51b0b

# Current SystemConfig owner: 0x01D33E0D8801f1Aa5E71bff7b7548C3f857a06F2
# SystemConfig ownership transferred to 0x39cb5B122B616239554621c866760272c8C2008e, tx: 0x144c797c698440e4e6f24b34e483621b0e3c4c50ef2d9320cb371b4d58c3eb1e

# Current Challenge owner: 0x01D33E0D8801f1Aa5E71bff7b7548C3f857a06F2
# Challenge ownership transferred to 0x39cb5B122B616239554621c866760272c8C2008e, tx: 0xd8557b0fd65157cf9820c5bc0fa14a63c643b2f2c4127ad9d1c69adbb1c34974
# Ownership transfer complete!
```